### PR TITLE
Auth Controller, Service 생성

### DIFF
--- a/src/main/java/com/gpsiu/gamepc/controller/AuthController.java
+++ b/src/main/java/com/gpsiu/gamepc/controller/AuthController.java
@@ -1,0 +1,38 @@
+package com.gpsiu.gamepc.controller;
+
+import com.gpsiu.gamepc.domain.Member;
+import com.gpsiu.gamepc.dto.Login;
+import com.gpsiu.gamepc.service.AuthService;
+import com.gpsiu.gamepc.token.Token;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+@RestController
+public class AuthController {
+    private final AuthService authService;
+
+    @PostMapping("/login")
+    public ResponseEntity<Token> authenticate(@RequestBody Login login){
+        return authService.authenticate(login.getUsername(), login.getPassword())
+                .map(ResponseEntity::ok)
+                .orElseGet(() -> ResponseEntity.badRequest().build());
+    }
+
+    @PostMapping("/reissue")
+    public ResponseEntity<Token> reissue(@RequestBody Token token){
+        return authService.reissue(token.getRefreshToken())
+                .map(ResponseEntity::ok)
+                .orElseGet(() -> ResponseEntity.badRequest().build());
+    }
+}

--- a/src/main/java/com/gpsiu/gamepc/dto/Login.java
+++ b/src/main/java/com/gpsiu/gamepc/dto/Login.java
@@ -1,0 +1,18 @@
+package com.gpsiu.gamepc.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+public class Login {
+    private String username;
+    private String password;
+
+    @Builder
+    public Login(String username, String password) {
+        this.username = username;
+        this.password = password;
+    }
+}

--- a/src/main/java/com/gpsiu/gamepc/security/SecurityConfig.java
+++ b/src/main/java/com/gpsiu/gamepc/security/SecurityConfig.java
@@ -3,6 +3,7 @@ package com.gpsiu.gamepc.security;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -19,6 +20,12 @@ import static org.springframework.security.config.http.SessionCreationPolicy.STA
 public class SecurityConfig extends WebSecurityConfigurerAdapter {
     private final UserDetailsService userDetailsService;
     private final PasswordEncoder passwordEncoder;
+
+    @Bean
+    @Override
+    public AuthenticationManager authenticationManagerBean() throws Exception {
+        return super.authenticationManagerBean();
+    }
 
     @Override
     protected void configure(AuthenticationManagerBuilder auth) throws Exception {

--- a/src/main/java/com/gpsiu/gamepc/service/AuthService.java
+++ b/src/main/java/com/gpsiu/gamepc/service/AuthService.java
@@ -1,0 +1,10 @@
+package com.gpsiu.gamepc.service;
+
+import com.gpsiu.gamepc.token.Token;
+
+import java.util.Optional;
+
+public interface AuthService{
+    Optional<Token> authenticate(String username, String password);
+    Optional<Token> reissue(String refreshToken);
+}

--- a/src/main/java/com/gpsiu/gamepc/service/AuthServiceImpl.java
+++ b/src/main/java/com/gpsiu/gamepc/service/AuthServiceImpl.java
@@ -1,0 +1,43 @@
+package com.gpsiu.gamepc.service;
+
+import com.gpsiu.gamepc.token.Token;
+import com.gpsiu.gamepc.token.TokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class AuthServiceImpl implements AuthService{
+    private final AuthenticationManager authenticationManager;
+    private final TokenProvider tokenProvider;
+
+    @Override
+    public Optional<Token> authenticate(String username, String password) {
+        UsernamePasswordAuthenticationToken authenticationToken =
+                new UsernamePasswordAuthenticationToken(username, password);
+        try {
+            Authentication authentication = authenticationManager.authenticate(authenticationToken);
+        } catch (Exception e) {
+            return Optional.empty();
+        }
+
+        return Optional.ofNullable(tokenProvider.createToken(username));
+    }
+
+    @Override
+    public Optional<Token> reissue(String refreshToken) {
+        if (tokenProvider.validateToken(refreshToken)) {
+            String username = tokenProvider.getUsername(refreshToken);
+            return Optional.ofNullable(tokenProvider.createToken(username));
+        } else {
+            return Optional.empty();
+        }
+    }
+}

--- a/src/main/java/com/gpsiu/gamepc/token/TokenProvider.java
+++ b/src/main/java/com/gpsiu/gamepc/token/TokenProvider.java
@@ -99,6 +99,11 @@ public class TokenProvider implements InitializingBean {
         return new UsernamePasswordAuthenticationToken(claims.get("username"), null, authority);
     }
 
+    public String getUsername(String token) {
+        Claims claims = getClaims(token);
+        return claims.get("username").toString();
+    }
+
     private Claims getClaims(String token) {
         try {
             return Jwts

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,7 +20,7 @@ spring:
 
 jwt:
   header: Authorization
-  # spring-boot-jwt-tutorial-made-by-gpsiu-1q2w#E$R%T
-  secret-key: c3ByaW5nLWJvb3Qtand0LXR1dG9yaWFsLW1hZGUtYnktZ3BzaXUtMXEydyNFJFIlVA==
+  # spring-boot-gamepc-reservation-made-by-gpsiu-1q2w#E$R%T-i-wanna-be-a-nice-guy
+  secret-key: c3ByaW5nLWJvb3QtZ2FtZXBjLXJlc2VydmF0aW9uLW1hZGUtYnktZ3BzaXUtMXEydyNFJFIlVC1pLXdhbm5hLWJlLWEtbmljZS1ndXk=
   access-token-validity-in-seconds: 1800 # 초 단위
   refresh-token-validity-in-seconds: 604800


### PR DESCRIPTION
Auth관련 항목 생성 및 수정
 - AuthController: POST /login, POST /reissue
 - AuthService : 상기 내용의 서비스
 - application.yml : secret-key 수정(512bit)
 - TokenProvider : getUsername(token) 추가
 - Login : /login용 DTO
 - SecurityConfig : AuthenticationManager Bean 생성

Resolve: #16