### PR TITLE
Reservation, PC, TimeTable Entity 생성

### DIFF
--- a/src/main/java/com/gpsiu/gamepc/domain/DateType.java
+++ b/src/main/java/com/gpsiu/gamepc/domain/DateType.java
@@ -1,0 +1,19 @@
+package com.gpsiu.gamepc.domain;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+public enum DateType {
+    WEEKDAY, HOLIDAY;
+
+    @JsonCreator
+    public static DateType fromValue(String value) {
+        switch (value) {
+            case "WEEKDAY":
+                return DateType.WEEKDAY;
+            case "HOLIDAY":
+                return DateType.HOLIDAY;
+        }
+        return null;
+    }
+
+}

--- a/src/main/java/com/gpsiu/gamepc/domain/Member.java
+++ b/src/main/java/com/gpsiu/gamepc/domain/Member.java
@@ -17,6 +17,7 @@ import java.util.Collections;
 public class Member implements UserDetails {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "MEMBER_ID")
     private Long id;
 
     @Column(nullable = false)

--- a/src/main/java/com/gpsiu/gamepc/domain/Member.java
+++ b/src/main/java/com/gpsiu/gamepc/domain/Member.java
@@ -8,8 +8,10 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
 import javax.persistence.*;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 
 @Setter
 @NoArgsConstructor
@@ -29,6 +31,9 @@ public class Member implements UserDetails {
     @Column(nullable = false)
     private String name;
 
+    @OneToMany(mappedBy = "member", fetch = FetchType.LAZY)
+    private List<Reservation> reservations = new ArrayList<Reservation>();
+
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private Role role;
@@ -41,6 +46,14 @@ public class Member implements UserDetails {
         this.role = role;
     }
 
+    public void addReservation(Reservation reservation) {
+        this.reservations.add(reservation);
+        if (reservation.getMember() != this) {
+            reservation.setMember(this);
+        }
+    }
+
+
     public Long getId() {
         return id;
     }
@@ -51,6 +64,10 @@ public class Member implements UserDetails {
 
     public Role getRole() {
         return role;
+    }
+
+    public List<Reservation> getReservations() {
+        return reservations;
     }
 
     @Override

--- a/src/main/java/com/gpsiu/gamepc/domain/Pc.java
+++ b/src/main/java/com/gpsiu/gamepc/domain/Pc.java
@@ -1,0 +1,34 @@
+package com.gpsiu.gamepc.domain;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@Entity
+public class Pc {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "PC_ID")
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private Boolean enable;
+
+    @OneToMany(mappedBy = "pc")
+    private List<Reservation> reservations = new ArrayList<Reservation>();
+
+    public void addReservation(Reservation reservation) {
+        this.reservations.add(reservation);
+        if (reservation.getPc() != this) {
+            reservation.setPc(this);
+        }
+    }
+}

--- a/src/main/java/com/gpsiu/gamepc/domain/Reservation.java
+++ b/src/main/java/com/gpsiu/gamepc/domain/Reservation.java
@@ -1,0 +1,37 @@
+package com.gpsiu.gamepc.domain;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+
+import javax.persistence.*;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.Date;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@Entity
+public class Reservation {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "RESERVATION_ID")
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name="MEMBER_ID")
+    @Column(nullable = false)
+    private Member member;
+
+    @Column(nullable = false)
+    private Pc pc;
+
+    @Column(nullable = false)
+    private Timetable timetable;
+
+    @CreationTimestamp
+    @Column(nullable = false)
+    private LocalDateTime createTime;// = LocalDateTime.now();
+}

--- a/src/main/java/com/gpsiu/gamepc/domain/Reservation.java
+++ b/src/main/java/com/gpsiu/gamepc/domain/Reservation.java
@@ -8,10 +8,11 @@ import org.hibernate.annotations.CreationTimestamp;
 import javax.persistence.*;
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
 
 @Getter
-@Setter
 @NoArgsConstructor
 @Entity
 public class Reservation {
@@ -20,18 +21,43 @@ public class Reservation {
     @Column(name = "RESERVATION_ID")
     private Long id;
 
-    @ManyToOne
-    @JoinColumn(name="MEMBER_ID")
-    @Column(nullable = false)
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "MEMBER_ID")
     private Member member;
 
-    @Column(nullable = false)
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "PC_ID")
     private Pc pc;
 
-    @Column(nullable = false)
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "TIMETABLE_ID")
     private Timetable timetable;
 
     @CreationTimestamp
     @Column(nullable = false)
     private LocalDateTime createTime;// = LocalDateTime.now();
+
+    public void setMember(Member member) {
+        this.member = member;
+
+        if(!member.getReservations().contains(this)) {
+            member.getReservations().add(this);
+        }
+    }
+
+    public void setPc(Pc pc) {
+        this.pc = pc;
+
+        if(!pc.getReservations().contains(this)) {
+            pc.getReservations().add(this);
+        }
+    }
+
+    public void setTimetable(Timetable timetable) {
+        this.timetable = timetable;
+
+        if(!timetable.getReservations().contains(this)) {
+            timetable.getReservations().add(this);
+        }
+    }
 }

--- a/src/main/java/com/gpsiu/gamepc/domain/Timetable.java
+++ b/src/main/java/com/gpsiu/gamepc/domain/Timetable.java
@@ -1,0 +1,41 @@
+package com.gpsiu.gamepc.domain;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@Entity
+public class Timetable {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "TIMETABLE_ID")
+    private Long id;
+
+    @Temporal(TemporalType.TIME)
+    @Column(nullable = false)
+    Date startTime;
+
+    @Temporal(TemporalType.TIME)
+    @Column(nullable = false)
+    Date endTime;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    DateType dateType;
+
+    @OneToMany(mappedBy = "timetable")
+    private List<Reservation> reservations = new ArrayList<Reservation>();
+
+    public void addReservation(Reservation reservation) {
+        this.reservations.add(reservation);
+        if (reservation.getTimetable() != this) {
+            reservation.setTimetable(this);
+        }
+    }
+}


### PR DESCRIPTION
Many : Reservation Entity
One : Member, Pc, Timetable Entity
---
Reservation
 - id(PK), member_id(FK), pc_id(FK), timetable_id(FK), createTime(temporal)
 - 양방향 다대일 연관관계 매핑 완료

Member
 - Reservation과 역방향 매핑 완료

Pc
 - id(PK), name, enable

Timetable
 - id(PK), startTime(temporal), endTime(temporal), datatype(enum)

Reseravation이 해당 관계에서 Many이기에 모든 외래키를 관리한다.

Resolve: #20