### PR TITLE
Pc, Timetable Repository, Service, Controller 생성

### DIFF
--- a/src/main/java/com/gpsiu/gamepc/controller/PcController.java
+++ b/src/main/java/com/gpsiu/gamepc/controller/PcController.java
@@ -1,0 +1,38 @@
+package com.gpsiu.gamepc.controller;
+
+import com.gpsiu.gamepc.domain.Member;
+import com.gpsiu.gamepc.domain.Pc;
+import com.gpsiu.gamepc.service.PcService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RequestMapping("/api/pc")
+@RequiredArgsConstructor
+@RestController
+public class PcController {
+    private final PcService pcService;
+
+    @PreAuthorize("permitAll()")
+    @GetMapping("")
+    public ResponseEntity<List<Pc>> findAll(){
+        return ResponseEntity.ok().body(pcService.findAll());
+    }
+
+    @PreAuthorize("permitAll()")
+    @GetMapping("/{id}")
+    public ResponseEntity<Pc> findPcById(@PathVariable Long id){
+        return pcService.findPcById(id)
+                .map(ResponseEntity::ok)
+                .orElseGet(() -> ResponseEntity.noContent().build());
+    }
+
+    @PreAuthorize("hasAnyAuthority('ROLE_ADMIN')")
+    @PostMapping("")
+    public ResponseEntity<Pc> savePc(@RequestBody Pc pc){
+        return ResponseEntity.ok().body(pcService.savePc(pc));
+    }
+}

--- a/src/main/java/com/gpsiu/gamepc/controller/TimetableController.java
+++ b/src/main/java/com/gpsiu/gamepc/controller/TimetableController.java
@@ -1,0 +1,30 @@
+package com.gpsiu.gamepc.controller;
+
+import com.gpsiu.gamepc.domain.Timetable;
+import com.gpsiu.gamepc.service.TimetableService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RequestMapping("/api/timetable")
+@RequiredArgsConstructor
+@RestController
+public class TimetableController {
+    private final TimetableService timetableService;
+
+    @PreAuthorize("permitAll()")
+    @GetMapping("")
+    public ResponseEntity<List<Timetable>> findAll(){
+        return ResponseEntity.ok().body(timetableService.findAll());
+    }
+
+    //TODO: Timetable의 date가 deserialize가 안되는 경우가 있음. 추후 DTO로 변경하여 해결할 것
+    @PreAuthorize("hasAnyAuthority('ROLE_ADMIN')")
+    @PostMapping("")
+    public ResponseEntity<Timetable> savePc(@RequestBody Timetable timetable){
+        return ResponseEntity.ok().body(timetableService.save(timetable));
+    }
+}

--- a/src/main/java/com/gpsiu/gamepc/domain/Timetable.java
+++ b/src/main/java/com/gpsiu/gamepc/domain/Timetable.java
@@ -2,6 +2,7 @@ package com.gpsiu.gamepc.domain;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import javax.persistence.*;
 import java.util.ArrayList;
@@ -9,6 +10,7 @@ import java.util.Date;
 import java.util.List;
 
 @Getter
+@Setter
 @NoArgsConstructor
 @Entity
 public class Timetable {

--- a/src/main/java/com/gpsiu/gamepc/repository/PcRepository.java
+++ b/src/main/java/com/gpsiu/gamepc/repository/PcRepository.java
@@ -1,0 +1,13 @@
+package com.gpsiu.gamepc.repository;
+
+import com.gpsiu.gamepc.domain.Pc;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface PcRepository {
+    Pc save(Pc pc);
+    List<Pc> findAll();
+    Optional<Pc> findById(Long id);
+    Optional<Pc> findByName(String name);
+}

--- a/src/main/java/com/gpsiu/gamepc/repository/PcRepositoryImpl.java
+++ b/src/main/java/com/gpsiu/gamepc/repository/PcRepositoryImpl.java
@@ -1,0 +1,52 @@
+package com.gpsiu.gamepc.repository;
+
+import com.gpsiu.gamepc.domain.Member;
+import com.gpsiu.gamepc.domain.Pc;
+import org.springframework.stereotype.Repository;
+
+import javax.persistence.EntityManager;
+import javax.persistence.NoResultException;
+import javax.persistence.PersistenceContext;
+import javax.persistence.TypedQuery;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public class PcRepositoryImpl implements PcRepository{
+    @PersistenceContext
+    private EntityManager em;
+
+    @Override
+    public Pc save(Pc pc) {
+        em.persist(pc);
+        return pc;
+    }
+
+    @Override
+    public List<Pc> findAll() {
+        return em.createQuery("select p from Pc p", Pc.class)
+                .getResultList();
+    }
+
+    @Override
+    public Optional<Pc> findById(Long id) {
+        try {
+            return Optional.ofNullable(em.find(Pc.class, id));
+        } catch (NoResultException e) {
+            return Optional.empty();
+        }
+    }
+
+    @Override
+    public Optional<Pc> findByName(String name) {
+        TypedQuery<Pc> query = em.createQuery("select p from Pc p where name = :name", Pc.class);
+        try {
+            return Optional.ofNullable(
+                    query.setParameter("name", name)
+                            .getSingleResult()
+            );
+        } catch (NoResultException e) {
+            return Optional.empty();
+        }
+    }
+}

--- a/src/main/java/com/gpsiu/gamepc/repository/TimetableRepository.java
+++ b/src/main/java/com/gpsiu/gamepc/repository/TimetableRepository.java
@@ -1,0 +1,14 @@
+package com.gpsiu.gamepc.repository;
+
+import com.gpsiu.gamepc.domain.DateType;
+import com.gpsiu.gamepc.domain.Timetable;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface TimetableRepository {
+    Timetable save(Timetable timetable);
+    List<Timetable> findAll();
+    List<Timetable> findAllByDateType(DateType dateType);
+    Optional<Timetable> findById(Long id);
+}

--- a/src/main/java/com/gpsiu/gamepc/repository/TimetableRepositoryImpl.java
+++ b/src/main/java/com/gpsiu/gamepc/repository/TimetableRepositoryImpl.java
@@ -1,0 +1,47 @@
+package com.gpsiu.gamepc.repository;
+
+import com.gpsiu.gamepc.domain.DateType;
+import com.gpsiu.gamepc.domain.Member;
+import com.gpsiu.gamepc.domain.Timetable;
+import org.springframework.stereotype.Repository;
+
+import javax.persistence.EntityManager;
+import javax.persistence.NoResultException;
+import javax.persistence.PersistenceContext;
+import javax.persistence.TypedQuery;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public class TimetableRepositoryImpl implements TimetableRepository{
+    @PersistenceContext
+    private EntityManager em;
+
+    @Override
+    public Timetable save(Timetable timetable) {
+        em.persist(timetable);
+        return timetable;
+    }
+
+    @Override
+    public List<Timetable> findAll() {
+        return em.createQuery("select t from Timetable t", Timetable.class)
+                .getResultList();
+    }
+
+    @Override
+    public List<Timetable> findAllByDateType(DateType dateType) {
+        return em.createQuery("select t from Timetable t where dateType = :dateType", Timetable.class)
+                .setParameter("dateType", dateType)
+                .getResultList();
+    }
+
+    @Override
+    public Optional<Timetable> findById(Long id) {
+        try {
+            return Optional.ofNullable(em.find(Timetable.class, id));
+        } catch (NoResultException e) {
+            return Optional.empty();
+        }
+    }
+}

--- a/src/main/java/com/gpsiu/gamepc/service/PcService.java
+++ b/src/main/java/com/gpsiu/gamepc/service/PcService.java
@@ -1,0 +1,13 @@
+package com.gpsiu.gamepc.service;
+
+import com.gpsiu.gamepc.domain.Pc;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface PcService {
+    Pc savePc(Pc pc);
+    List<Pc> findAll();
+    Optional<Pc> findPcById(Long id);
+    Optional<Pc> findPcByName(String name);
+}

--- a/src/main/java/com/gpsiu/gamepc/service/PcServiceImpl.java
+++ b/src/main/java/com/gpsiu/gamepc/service/PcServiceImpl.java
@@ -1,0 +1,38 @@
+package com.gpsiu.gamepc.service;
+
+
+import com.gpsiu.gamepc.domain.Pc;
+import com.gpsiu.gamepc.repository.PcRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class PcServiceImpl implements PcService{
+    private final PcRepository pcRepository;
+
+    @Override
+    public Pc savePc(Pc pc) {
+        return pcRepository.save(pc);
+    }
+
+    @Override
+    public List<Pc> findAll() {
+        return pcRepository.findAll();
+    }
+
+    @Override
+    public Optional<Pc> findPcById(Long id) {
+        return pcRepository.findById(id);
+    }
+
+    @Override
+    public Optional<Pc> findPcByName(String name) {
+        return pcRepository.findByName(name);
+    }
+}

--- a/src/main/java/com/gpsiu/gamepc/service/TimetableService.java
+++ b/src/main/java/com/gpsiu/gamepc/service/TimetableService.java
@@ -1,0 +1,14 @@
+package com.gpsiu.gamepc.service;
+
+import com.gpsiu.gamepc.domain.DateType;
+import com.gpsiu.gamepc.domain.Timetable;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface TimetableService {
+    Timetable save(Timetable timetable);
+    List<Timetable> findAll();
+    List<Timetable> findAllByDateType(DateType dateType);
+    Optional<Timetable> findTimetableById(Long id);
+}

--- a/src/main/java/com/gpsiu/gamepc/service/TimetableServiceImpl.java
+++ b/src/main/java/com/gpsiu/gamepc/service/TimetableServiceImpl.java
@@ -1,0 +1,38 @@
+package com.gpsiu.gamepc.service;
+
+import com.gpsiu.gamepc.domain.DateType;
+import com.gpsiu.gamepc.domain.Timetable;
+import com.gpsiu.gamepc.repository.TimetableRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class TimetableServiceImpl implements TimetableService{
+    private final TimetableRepository timetableRepository;
+
+    @Override
+    public Timetable save(Timetable timetable) {
+        return timetableRepository.save(timetable);
+    }
+
+    @Override
+    public List<Timetable> findAll() {
+        return timetableRepository.findAll();
+    }
+
+    @Override
+    public List<Timetable> findAllByDateType(DateType dateType) {
+        return timetableRepository.findAllByDateType(dateType);
+    }
+
+    @Override
+    public Optional<Timetable> findTimetableById(Long id) {
+        return timetableRepository.findById(id);
+    }
+}


### PR DESCRIPTION
Pc와 Timetable Entity에 관련된 Repo, Service, Controller 생성

Pc
 - Repo: `save`, `findAll`, `findById`, `findByName`
 - Service: 상동
 - Controller: 
   - `GET /api/pc`, `GET /api/pc/{id}`, `POST /api/pc`

Timetable
 - Repo: `save`, `findAll`, `findAllByDateType`, `findById`
 - Service: 상동
 - Controller:
   - `GET /api/timetable`, `POST /api/timetable`

추후 DTO 구현하여 적용 시에, Date에 관련된 사항과 버그 수정 예정에 있음

Resolve: #22